### PR TITLE
Multiple fixes

### DIFF
--- a/modules/castbar_refactored.lua
+++ b/modules/castbar_refactored.lua
@@ -32,18 +32,18 @@ local UV_COORDS = {
 
 -- Configuración de canal ticks
 local CHANNEL_TICKS = {
-    -- Warlock
+    -- Brujo
     ["Drain Soul"] = 5,
     ["Drain Life"] = 5,
     ["Drain Mana"] = 5,
     ["Rain of Fire"] = 4,
     ["Hellfire"] = 15,
     ["Ritual of Summoning"] = 5,
-    -- Priest
+    -- Sacerdote
     ["Mind Flay"] = 3,
     ["Mind Control"] = 8,
     ["Penance"] = 2,
-    -- Mage
+    -- Mago
     ["Blizzard"] = 8,
     ["Evocation"] = 4,
     ["Arcane Missiles"] = 5,
@@ -156,7 +156,7 @@ local auraCache = {
 -- =================================================================
 
 local RefreshCastbar;
--- Forward declarations for functions used before definition
+-- Declaraciones anticipadas para funciones usadas antes de su definición
 local HandleCastStop;
 
 -- Función para forzar la capa correcta de StatusBar texture
@@ -203,7 +203,7 @@ local function GetSpellIconImproved(spellName, texture, castID)
         if spellTexture then
             return spellTexture
         end
-        -- Búsqueda en spellbook
+        -- Búsqueda en el libro de hechizos
         for i = 1, 1024 do
             local name, _, icon = GetSpellInfo(i, BOOKTYPE_SPELL);
             if not name then
@@ -909,7 +909,7 @@ local function HandleCastStop(castbarType, event, isInterrupted)
             frameData.castbar:UpdateTextureClipping(1.0, false); -- Mostrar completo sin recorte
         end
 
-        SetCastText(castbarType, "Interrupted");
+        SetCastText(castbarType, "Interrumpido");
 
         state.casting = false;
         state.isChanneling = false;
@@ -940,11 +940,11 @@ local function UpdateCastbar(castbarType, self, elapsed)
             return
         end
 
-        -- FIXED: Check if target/focus still exists - if not, immediately hide castbar
+        -- CORREGIDO: Comprobar si el objetivo/foco todavía existe - si no, ocultar inmediatamente la barra de lanzamiento
         local unit = castbarType;
         if not UnitExists(unit) then
             if state.casting or state.isChanneling then
-                -- Target/focus died or disappeared during casting - hide castbar immediately
+                -- El objetivo/foco murió o desapareció durante el lanzamiento - ocultar la barra de lanzamiento inmediatamente
                 self:Hide();
                 if frameData.background then
                     frameData.background:Hide()
@@ -965,7 +965,7 @@ local function UpdateCastbar(castbarType, self, elapsed)
                     frameData.icon:Hide()
                 end
 
-                -- Reset state
+                -- Restablecer estado
                 state.casting = false;
                 state.isChanneling = false;
                 state.holdTime = 0;
@@ -977,9 +977,9 @@ local function UpdateCastbar(castbarType, self, elapsed)
     elseif not cfg or not cfg.enabled then
         return;
     else
-        -- FIXED: For player castbar, check if target exists when casting target spells
+        -- CORREGIDO: Para la barra de lanzamiento del jugador, comprobar si el objetivo existe al lanzar hechizos de objetivo
         if (state.casting or state.isChanneling) and state.currentSpellName then
-            -- Common target spells that should be interrupted if target dies
+            -- Hechizos de objetivo comunes que deben interrumpirse si el objetivo muere
             local targetSpells = {
                 ["Fireball"] = true,
                 ["Frostbolt"] = true,
@@ -1001,9 +1001,9 @@ local function UpdateCastbar(castbarType, self, elapsed)
                 ["Corruption"] = true
             };
 
-            -- If casting a target spell and target doesn't exist, cancel the cast
+            -- Si se está lanzando un hechizo de objetivo y el objetivo no existe, cancelar el lanzamiento
             if targetSpells[state.currentSpellName] and not UnitExists("target") then
-                -- Target died during player casting - hide castbar immediately
+                -- El objetivo murió durante el lanzamiento del jugador - ocultar la barra de lanzamiento inmediatamente
                 self:Hide();
                 if frameData.background then
                     frameData.background:Hide()
@@ -1024,7 +1024,7 @@ local function UpdateCastbar(castbarType, self, elapsed)
                     frameData.icon:Hide()
                 end
 
-                -- Reset state
+                -- Restablecer estado
                 state.casting = false;
                 state.isChanneling = false;
                 state.holdTime = 0;
@@ -1102,24 +1102,24 @@ local function UpdateCastbar(castbarType, self, elapsed)
 
     -- Usar valores perfectos de Blizzard para casts y channels
     if state.casting or state.isChanneling then
-        -- FIXED: Detect silent interruptions (e.g., from CC or other game mechanics)
+        -- CORREGIDO: Detectar interrupciones silenciosas (p. ej., de CC u otras mecánicas del juego)
         local unit = castbarType == "player" and "player" or castbarType;
         local isStillCasting = UnitCastingInfo(unit);
         local isStillChanneling = UnitChannelInfo(unit);
 
         if not isStillCasting and not isStillChanneling then
-            -- The game says we are not casting/channeling, but our addon thinks we are.
-            -- This is a silent interruption.
+            -- El juego dice que no estamos lanzando/canalizando, pero nuestro addon cree que sí.
+            -- Esto es una interrupción silenciosa.
             if HandleCastStop then
                 HandleCastStop(castbarType, 'UNIT_SPELLCAST_INTERRUPTED', true);
             else
-                -- Fallback: hide castbar immediately
+                -- Alternativa: ocultar la barra de lanzamiento inmediatamente
                 self:Hide();
                 state.casting = false;
                 state.isChanneling = false;
                 state.holdTime = 0;
             end
-            return; -- Stop further processing for this frame
+            return; -- Detener el procesamiento posterior para este fotograma
         end
         -- No sincronizar con Blizzard durante período de gracia
         local shouldSync = true;
@@ -1137,7 +1137,15 @@ local function UpdateCastbar(castbarType, self, elapsed)
             if castbarType == "player" then
                 if state.spellStartTime > 0 and state.spellEndTime > 0 then
                     local now = GetTime();
-                    self:SetValue(math.min(now, state.spellEndTime));
+                    
+                    -- CORRECCIÓN: Para la canalización, forzar la barra a su valor máximo para que el
+                    -- sistema de recorte de textura sea el único responsable del efecto de drenaje.
+                    -- De lo contrario, la barra crece mientras la textura se encoge, creando una imagen confusa.
+                    if state.isChanneling then
+                        self:SetValue(state.spellEndTime);
+                    else
+                        self:SetValue(math.min(now, state.spellEndTime));
+                    end
 
                     local totalDuration = state.spellEndTime - state.spellStartTime;
                     local progress = 0;
@@ -1145,6 +1153,11 @@ local function UpdateCastbar(castbarType, self, elapsed)
                         progress = (now - state.spellStartTime) / totalDuration;
                     end
                     progress = math.max(0, math.min(1, progress));
+
+                    -- CORRECCIÓN: El progreso de la canalización del jugador debe invertirse para el efecto de drenaje de derecha a izquierda.
+                    if state.isChanneling then
+                        progress = 1.0 - progress
+                    end
 
                     if self.UpdateTextureClipping then
                         self:UpdateTextureClipping(progress, state.isChanneling);
@@ -1186,6 +1199,10 @@ local function UpdateCastbar(castbarType, self, elapsed)
             if castbarType == "player" then
                 if state.spellEndTime > state.spellStartTime then
                     progress = (GetTime() - state.spellStartTime) / (state.spellEndTime - state.spellStartTime);
+                    -- CORRECCIÓN: La chispa también debe moverse de derecha a izquierda para la canalización, por lo que también invertimos su progreso.
+                    if state.isChanneling then
+                        progress = 1.0 - progress
+                    end
                 end
             else
                 if state.maxValue > 0 then
@@ -1379,7 +1396,7 @@ local function HandleChannelStart(castbarType, unit)
         frameData.castbar:SetMinMaxValues(startTimeSeconds, endTimeSeconds);
         frameData.castbar:SetValue(GetTime());
     else
-        -- CRITICAL FIX: Para channeling empezar desde max y contar hacia abajo
+        -- CORRECCIÓN CRÍTICA: Para la canalización, empezar desde el máximo y contar hacia abajo
         state.maxValue = spellDuration;
         state.currentValue = spellDuration; -- Empezar desde el máximo para channeling
         frameData.castbar:SetMinMaxValues(0, state.maxValue);
@@ -1401,7 +1418,7 @@ local function HandleChannelStart(castbarType, unit)
 
     -- CORREGIDO: Color correcto para player channeling
     if castbarType == "player" then
-        frameData.castbar:SetStatusBarColor(0, 1, 0, 1); -- Verde para player
+        frameData.castbar:SetStatusBarColor(1, 1, 1, 1); -- Usar blanco para no teñir la textura y evitar fondo sólido
     else
         frameData.castbar:SetStatusBarColor(1, 1, 1, 1); -- Blanco para target/focus
     end
@@ -1610,7 +1627,7 @@ end
 -- SISTEMA DE CREACIÓN DE CASTBARS UNIFICADO
 -- =================================================================
 
--- Sistema de recorte dinámico  usando coordenadas UV
+-- Sistema de recorte dinámico usando coordenadas UV
 local function CreateTextureClippingSystem(statusBar)
 
     statusBar.UpdateTextureClipping = function(self, progress, isChanneling)
@@ -1619,26 +1636,39 @@ local function CreateTextureClippingSystem(statusBar)
             return
         end
 
-        -- Asegurar que la textura llene todo el frame
-        currentTexture:ClearAllPoints();
-        currentTexture:SetPoint('TOPLEFT', self, 'TOPLEFT', 0, 0);
-        currentTexture:SetPoint('BOTTOMRIGHT', self, 'BOTTOMRIGHT', 0, 0);
-
-        -- CRITICAL: Forzar que la StatusBar texture esté en la capa correcta
-        -- En WoW 3.3.5a, algunas veces se reposiciona mal después de SetStatusBarTexture
+        -- CRÍTICO: Forzar que la textura de la StatusBar esté en la capa correcta
         if currentTexture.SetDrawLayer then
             currentTexture:SetDrawLayer('BORDER', 0);
         end
 
         -- Aplicar recorte dinámico profesional usando coordenadas UV
-        local clampedProgress = math.max(0.001, math.min(1, progress)); -- Evitar valores extremos
+        local clampedProgress = math.max(0, math.min(1, progress)); -- Clamp from 0 to 1
 
         if isChanneling then
-            -- Para channeling: mostrar como barra que se vacía de derecha a izquierda
-            -- progress va de 1.0 a 0.0, mostramos desde izquierda hasta esa posición
-            currentTexture:SetTexCoord(0, clampedProgress, 0, 1);
+            -- Para channeling, la barra se vacía de derecha a izquierda.
+            -- 'progress' es el tiempo restante (1.0 -> 0.0).
+            local elapsedProgress = 1.0 - clampedProgress;
+
+            -- 1. Anclamos la textura a la izquierda y ajustamos su tamaño para que se encoja
+            currentTexture:ClearAllPoints();
+            currentTexture:SetPoint("TOPLEFT", self, "TOPLEFT");
+            currentTexture:SetPoint("BOTTOMLEFT", self, "BOTTOMLEFT");
+            currentTexture:SetSize(self:GetWidth() * clampedProgress, self:GetHeight());
+            
+            -- 2. Desplazamos las coordenadas de la textura para que siga animándose
+            -- Esto crea la ilusión de que la textura se mueve a través de la barra que se encoge.
+            currentTexture:SetTexCoord(elapsedProgress, elapsedProgress + clampedProgress, 0, 1);
+
         else
-            -- Para casting: recorte de izquierda a derecha (empezar vacío, llenarse)
+            -- Para casting: la barra se llena de izquierda a derecha.
+            -- 'progress' es el tiempo transcurrido (0.0 -> 1.0).
+
+            -- Asegurar que la textura llene todo el frame si no está casteando
+            currentTexture:ClearAllPoints();
+            currentTexture:SetPoint('TOPLEFT', self, 'TOPLEFT', 0, 0);
+            currentTexture:SetPoint('BOTTOMRIGHT', self, 'BOTTOMRIGHT', 0, 0);
+            
+            -- Recortamos la textura mostrando solo la parte correspondiente al progreso.
             currentTexture:SetTexCoord(0, clampedProgress, 0, 1);
         end
     end;
@@ -1817,7 +1847,7 @@ end
 
 -- Función unificada para refresh de castbars
 RefreshCastbar = function(castbarType)
-    -- CRITICAL: Protección contra refreshes muy frecuentes (causa problemas de capas)
+    -- CRÍTICO: Protección contra refreshes muy frecuentes (causa problemas de capas)
     local currentTime = GetTime();
     local timeSinceLastRefresh = currentTime - (lastRefreshTime[castbarType] or 0);
     -- No permitir refreshes más frecuentes que cada 0.1 segundos (excepto primer refresh)
@@ -1893,7 +1923,7 @@ RefreshCastbar = function(castbarType)
     frameData.castbar:SetSize(cfg.sizeX or 200, cfg.sizeY or 16);
     frameData.castbar:SetScale(cfg.scale or 1);
 
-    -- CRITICAL: Crear/configurar spark DESPUÉS de que el frame padre esté completamente configurado
+    -- CRÍTICO: Crear/configurar la chispa DESPUÉS de que el frame padre esté completamente configurado
     if not frameData.spark then
         -- Convertir el spark en un frame independiente para un control de capas superior
         frameData.spark = CreateFrame("Frame", frameName .. "Spark", UIParent);

--- a/modules/castbar_refactored.lua
+++ b/modules/castbar_refactored.lua
@@ -1766,8 +1766,11 @@ local function CreateCastbar(castbarType)
     frameData.ticks = {};
     CreateChannelTicks(frameData.castbar, frameData.ticks, 15);
 
-    -- PASO 5: SPARK - SE CREARÁ DESPUÉS EN RefreshCastbar() cuando el frame esté posicionado
-    frameData.spark = nil; -- Placeholder
+    -- PASO 5: SPARK (OVERLAY layer) - CORREGIDO
+    frameData.spark = frameData.castbar:CreateTexture(nil, 'OVERLAY', nil, 1);
+    frameData.spark:SetTexture(TEXTURES.spark);
+    frameData.spark:SetBlendMode('ADD');
+    frameData.spark:Hide();
 
     -- PASO 6: FLASH DE COMPLETADO (OVERLAY layer)
     frameData.flash = frameData.castbar:CreateTexture(nil, 'OVERLAY');
@@ -1852,7 +1855,6 @@ RefreshCastbar = function(castbarType)
     local timeSinceLastRefresh = currentTime - (lastRefreshTime[castbarType] or 0);
     -- No permitir refreshes más frecuentes que cada 0.1 segundos (excepto primer refresh)
     if timeSinceLastRefresh < 0.1 and (lastRefreshTime[castbarType] or 0) > 0 then
-        -- Descomentar para debug: print("[DragonUI Castbar] BLOCKED rapid refresh for " .. castbarType .. " (time since last: " .. string.format("%.3f", timeSinceLastRefresh) .. "s)");
         return;
     end
 
@@ -1922,23 +1924,7 @@ RefreshCastbar = function(castbarType)
     frameData.castbar:SetPoint(anchorPoint, anchorFrame, relativePoint, xPos, yPos - auraOffset);
     frameData.castbar:SetSize(cfg.sizeX or 200, cfg.sizeY or 16);
     frameData.castbar:SetScale(cfg.scale or 1);
-
-    -- CRÍTICO: Crear/configurar la chispa DESPUÉS de que el frame padre esté completamente configurado
-    if not frameData.spark then
-        -- Convertir el spark en un frame independiente para un control de capas superior
-        frameData.spark = CreateFrame("Frame", frameName .. "Spark", UIParent);
-        frameData.spark:SetFrameStrata("MEDIUM");
-        frameData.spark:SetFrameLevel(11); -- Nivel superior al castbar (10)
-        frameData.spark:SetSize(16, 16);
-        frameData.spark:SetPoint('CENTER', frameData.castbar, 'LEFT', 0, 0);
-        frameData.spark:Hide();
-
-        local sparkTexture = frameData.spark:CreateTexture(nil, 'ARTWORK');
-        sparkTexture:SetTexture(TEXTURES.spark);
-        sparkTexture:SetAllPoints(frameData.spark);
-        sparkTexture:SetBlendMode('ADD');
-    end
-
+    
     -- Posicionar frame de fondo de texto
     if frameData.textBackground then
         frameData.textBackground:ClearAllPoints();
@@ -2004,10 +1990,9 @@ RefreshCastbar = function(castbarType)
 
     -- Actualizar tamaño del spark (proporcional a la altura del castbar)
     if frameData.spark then
-        local sparkSize = cfg.sizeY or 16;
-        frameData.spark:SetSize(sparkSize, sparkSize * 2);
-        frameData.spark:ClearAllPoints();
-        frameData.spark:SetPoint('CENTER', frameData.castbar, 'LEFT', 0, 0);
+        local sparkHeight = (cfg.sizeY or 16) * 2;
+        local sparkWidth = sparkHeight / 2; -- Mantener la proporción
+        frameData.spark:SetSize(sparkWidth, sparkHeight);
     end
 
     -- Actualizar tamaños de ticks

--- a/modules/castbar_refactored.lua
+++ b/modules/castbar_refactored.lua
@@ -909,7 +909,7 @@ local function HandleCastStop(castbarType, event, isInterrupted)
             frameData.castbar:UpdateTextureClipping(1.0, false); -- Mostrar completo sin recorte
         end
 
-        SetCastText(castbarType, "Interrumpido");
+        SetCastText(castbarType, "Interrupted");
 
         state.casting = false;
         state.isChanneling = false;

--- a/modules/unitframe.lua
+++ b/modules/unitframe.lua
@@ -1857,6 +1857,54 @@ function unitframe.UpdatePlayerFrameTextSelective(showHealth, showMana)
             dragonFrame.PlayerFrameManaBarTextRight:SetText("")
             dragonFrame.PlayerFrameManaBarTextRight:Hide()
         end
+	end
+		
+	-- Handle Druid Alternate Mana Bar
+    if PlayerFrameAlternateManaBar and PlayerFrameAlternateManaBar:IsVisible() then
+        if not _G["DragonUIDruidManaText"] then
+            local text = PlayerFrameAlternateManaBar:CreateFontString("DragonUIDruidManaText", "OVERLAY", "TextStatusBarText")
+            text:SetPoint("CENTER", PlayerFrameAlternateManaBar, "CENTER", 0, 0)
+        end
+        if not _G["DragonUIDruidManaTextLeft"] then
+            local textLeft = PlayerFrameAlternateManaBar:CreateFontString("DragonUIDruidManaTextLeft", "OVERLAY", "TextStatusBarText")
+            textLeft:SetPoint("LEFT", PlayerFrameAlternateManaBar, "LEFT", 6, 0)
+            textLeft:SetJustifyH("LEFT")
+        end
+        if not _G["DragonUIDruidManaTextRight"] then
+            local textRight = PlayerFrameAlternateManaBar:CreateFontString("DragonUIDruidManaTextRight", "OVERLAY", "TextStatusBarText")
+            textRight:SetPoint("RIGHT", PlayerFrameAlternateManaBar, "RIGHT", -6, 0)
+            textRight:SetJustifyH("RIGHT")
+        end
+        
+        local textFrame = _G["DragonUIDruidManaText"]
+        local textFrameLeft = _G["DragonUIDruidManaTextLeft"]
+        local textFrameRight = _G["DragonUIDruidManaTextRight"]
+
+        if showMana then
+            local mana, maxMana = UnitPower("player", 0), UnitPowerMax("player", 0)
+            local formattedText = FormatStatusText(mana, maxMana, config.textFormat, config.breakUpLargeNumbers, "player")
+
+            if type(formattedText) == "table" then
+                textFrameLeft:SetText(formattedText.percentage or "")
+                textFrameRight:SetText(formattedText.current or "")
+                textFrameLeft:Show()
+                textFrameRight:Show()
+                textFrame:Hide()
+            else
+                textFrame:SetText(formattedText)
+                textFrame:Show()
+                textFrameLeft:Hide()
+                textFrameRight:Hide()
+            end
+        else
+            textFrame:Hide()
+            textFrameLeft:Hide()
+            textFrameRight:Hide()
+        end
+    elseif _G["DragonUIDruidManaText"] then
+        _G["DragonUIDruidManaText"]:Hide()
+        if _G["DragonUIDruidManaTextLeft"] then _G["DragonUIDruidManaTextLeft"]:Hide() end
+        if _G["DragonUIDruidManaTextRight"] then _G["DragonUIDruidManaTextRight"]:Hide() end
     end
 end
 
@@ -7849,4 +7897,3 @@ profileCallbackFrame:SetScript("OnEvent", function(self, event, addonName)
         self:UnregisterEvent("ADDON_LOADED")
     end
 end)
-

--- a/modules/unitframe.lua
+++ b/modules/unitframe.lua
@@ -945,7 +945,11 @@ function unitframe:ApplySettings()
         else
             unitframe.MoveTargetFrame(objLocal.anchor, objLocal.anchorParent, objLocal.x, objLocal.y)
         end
+		-- Support for Combo Points scaling
         TargetFrame:SetScale(obj.scale)
+			if ComboFrame and TargetFrame then
+				ComboFrame:SetScale(TargetFrame:GetScale() or 1)
+			end
         -- unitframe.ReApplyTargetFrame() -- REMOVED: Redundant call.
         -- unitframe.ChangeToT() -- REMOVED: Redundant call.
         -- if UnitExists('targettarget') then -- REMOVED: Redundant call.


### PR DESCRIPTION
Hi,

This pull request addresses several issues, primarily fixing the player castbar which did not correctly handle spell pushback when taking damage. The bar would continue to progress normally without showing the delay.

**Changes:**

*   Registered the UNIT\_SPELLCAST\_DELAYED and UNIT\_SPELLCAST\_CHANNEL\_UPDATE events for the player unit.
    
*   The castbar's update logic has been switched to an absolute time model (using GetTime()) to ensure its progress is always in sync with the actual spell completion time, including any delays.
    
*   Corrected the fill direction for channeled spells to deplete from right to left.
    
*   Fixed a scaling issue where combo points would not resize correctly along with the target frame.
    
*   Enhanced the "Always Show Mana Text" option to also apply to the alternate power bar for Druids in shapeshift forms.
    

As a result, the castbar now visually "jumps back" when the player is hit, accurately reflecting the spell's new, longer cast time, and other UI elements are more consistent and reliable.

Thanks for considering the contribution!