### PR TITLE
feat: Add addon icon radius setting and update button positioning logic

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -232,7 +232,8 @@ local defaults = {
             mail_icon_x = -4,
             mail_icon_y = -5,
             addon_button_skin = true,
-            addon_button_fade = false
+            addon_button_fade = false,
+            addon_icon_radius = 90
         },
 
         --  BUFFS SETTINGS (NUEVO)

--- a/options.lua
+++ b/options.lua
@@ -1583,6 +1583,28 @@ function addon:CreateOptionsTable()
                         order = 5.1
                     },
 
+                    addon_icon_radius = {
+                        type = 'range',
+                        name = "Addon Icon Radius",
+                        desc = "Distance of addon icons from the center of the minimap",
+                        min = 60,
+                        max = 120,
+                        step = 5,
+                        disabled = function()
+                            return not addon.db.profile.minimap.addon_button_skin
+                        end,
+                        get = function()
+                            return addon.db.profile.minimap.addon_icon_radius
+                        end,
+                        set = function(info, value)
+                            addon.db.profile.minimap.addon_icon_radius = value
+                            if addon.RefreshMinimap then
+                                addon:RefreshMinimap()
+                            end
+                        end,
+                        order = 5.2
+                    },
+
                     player_arrow_size = {
                         type = 'range',
                         name = "Player Arrow Size",


### PR DESCRIPTION
to fix #92

Fixed minimap radius for rendering icons and added a settings page configuration for radius, now people can set how far from center icons should render.