### PR TITLE
fix(castbar): correct aura counting and offset calculation for target castbar

### DIFF
--- a/modules/castbar.lua
+++ b/modules/castbar.lua
@@ -488,7 +488,7 @@ local function GetAuraOffset(unit)
         if debuffCount > 0 then
             local debuffRows = ceil(debuffCount / AURAS_PER_ROW)
             -- Include ALL debuff rows in the offset calculation
-            totalOffset = totalOffset + ((debuffRows - 1) * AURA_ROW_HEIGHT)
+            totalOffset = totalOffset + ((debuffRows) * AURA_ROW_HEIGHT)
         end
     end
     


### PR DESCRIPTION
- Changed AURAS_PER_ROW from 8 to 6 (WotLK 3.3.5a standard)
- Fixed buff row calculation to include all rows instead of (rows - 1)
- Fixed debuff row calculation to count all rows instead of assuming single row
- Ensures castbar positions correctly below all auras without overlap