### PR TITLE
Fix stack overflow in ScanFrame when Questie (or similar) is enabled

### DIFF
--- a/DragonUI/modules/minimap.lua
+++ b/DragonUI/modules/minimap.lua
@@ -1443,9 +1443,13 @@ local function GetAllMinimapButtons()
         if not parentFrame then
             return
         end
-
-        local children = { parentFrame:GetChildren() }
-        for i = 1, #children do
+        
+-- Addons like Questie parent hundreds of map pins directly to Minimap, which overflows the Lua
+-- C stack before we can filter them. pcall catches that error so we fail gracefully instead of
+-- spamming an error every frame.
+    local ok, children = pcall(function() return { parentFrame:GetChildren() } end)
+    if not ok then return end
+    for i = 1, #children do
             local child = children[i]
             if not child then
             elseif child:GetObjectType() == "Button" then

--- a/DragonUI/modules/minimap.lua
+++ b/DragonUI/modules/minimap.lua
@@ -1444,12 +1444,12 @@ local function GetAllMinimapButtons()
             return
         end
         
--- Addons like Questie parent hundreds of map pins directly to Minimap, which overflows the Lua
--- C stack before we can filter them. pcall catches that error so we fail gracefully instead of
--- spamming an error every frame.
-    local ok, children = pcall(function() return { parentFrame:GetChildren() } end)
-    if not ok then return end
-    for i = 1, #children do
+        -- Addons like Questie parent hundreds of map pins directly to Minimap, which overflows the Lua
+        -- C stack before we can filter them. pcall catches that error so we fail gracefully instead of
+        -- spamming an error every frame.
+        local ok, children = pcall(function() return { parentFrame:GetChildren() } end)
+        if not ok then return end
+        for i = 1, #children do
             local child = children[i]
             if not child then
             elseif child:GetObjectType() == "Button" then


### PR DESCRIPTION
When Questie is enabled alongside DragonUI, the minimap module throws a Stack overflow error on every frame

Questie parents one Button per quest objective directly to the Minimap frame: potentially hundreds of children.  WoW 3.3.5a's stack limit is ~200 slots, so with enough quest pins active, the single call { parentFrame:GetChildren() } overflows the stack before any filtering code can run.

Wrapping GetChildren in a pcall catches this cleanly