### PR TITLE
fix(castbar): ignore cast events belonging to another spell

### DIFF
--- a/DragonUI/modules/castbar.lua
+++ b/DragonUI/modules/castbar.lua
@@ -1221,7 +1221,7 @@ function CastbarModule:HandleCastStart_Simple(unitType, unit, isChanneling)
 
     if isChanneling then
         spell, _, _, icon, startTime, endTime, _, notInterruptible = UnitChannelInfo(unit)
-        castID = nil  -- channels carry no castID in 3.3.5a
+        castID = nil -- UnitChannelInfo has no castID in 3.3.5a
     else
         spell, _, _, icon, startTime, endTime, _, castID, notInterruptible = UnitCastingInfo(unit)
     end
@@ -1246,9 +1246,7 @@ function CastbarModule:HandleCastStart_Simple(unitType, unit, isChanneling)
     castbar.startTime = start
     castbar.endTime = finish
     castbar.spellName = spell
-    -- castID is the authority for matching later FAILED / INTERRUPTED events to this exact
-    -- cast (Blizzard CastingBarFrame model). nil for channels, which have none in 3.3.5a.
-    castbar.castID = castID
+    castbar.castID = castID -- match FAILED/INTERRUPTED like CastingBarFrame (nil for channels)
 
     -- Cancel any active fade
     castbar.fadeOutEx = false
@@ -1500,11 +1498,7 @@ function CastbarModule:HandleCastStop_Simple(unitType, wasInterrupted, isChannel
     end
 end
 
-function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell, eventRank, eventCastID)
-    -- UNIT_SPELLCAST_FAILED fires for several reasons: a spell that failed to start, a
-    -- re-press rejected mid-cast, another macro spell failing, or the tracked cast being
-    -- interrupted. Case "re-press" carries the SAME spell name as the tracked cast, so the
-    -- name alone cannot tell it apart. castID can: Blizzard's own cast bar matches on it.
+function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell, _, eventCastID)
     local frames = self.frames[unitType]
     if not frames or not frames.castbar then return end
     local castbar = frames.castbar
@@ -1512,7 +1506,7 @@ function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell, eventRank, 
 
     local unit = (unitType == "player") and "player" or unitType
 
-    -- Ignore FAILED spam produced by re-pressing the same channel while it is still active.
+    -- Ignore FAILED spam from re-pressing the same channel while it is still active.
     if castbar.channelingEx then
         local activeChannelSpell = UnitChannelInfo(unit)
         if activeChannelSpell and castbar.spellName and activeChannelSpell == castbar.spellName then
@@ -1520,11 +1514,7 @@ function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell, eventRank, 
         end
     end
 
-    -- castID is the authority, not the spell name. A rejected re-press carries the SAME name
-    -- as the tracked cast but a DIFFERENT castID; another macro spell (e.g. Auto Shot while
-    -- moving) has its own castID too. Both are ignored. A genuine failure/interrupt of the
-    -- tracked cast carries its castID, so it still gets through. Channels have no castID in
-    -- 3.3.5a and fall back to the spell-name guard.
+    -- Same-name re-press / other macro spells differ by castID; channels fall back to name.
     if castbar.castID then
         if eventCastID ~= castbar.castID then
             return
@@ -1536,11 +1526,8 @@ function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell, eventRank, 
     self:HandleCastStop_Simple(unitType, true, nil, FAILED)
 end
 
--- UNIT_SPELLCAST_INTERRUPTED used to be dispatched straight to
--- HandleCastStop_Simple(unitType, true) with no verification, so an interruption belonging
--- to ANOTHER spell wiped the bar of the cast in progress. Verify castID the same way
--- HandleCastFailed_Simple does before acting on it.
-function CastbarModule:HandleCastInterrupted_Simple(unitType, isChannel, eventSpell, eventRank, eventCastID)
+-- INTERRUPTED used to kill any active bar; gate on castID (or spell name for channels).
+function CastbarModule:HandleCastInterrupted_Simple(unitType, isChannel, eventSpell, _, eventCastID)
     local frames = self.frames[unitType]
     if not frames or not frames.castbar then return end
     local castbar = frames.castbar

--- a/DragonUI/modules/castbar.lua
+++ b/DragonUI/modules/castbar.lua
@@ -1217,12 +1217,13 @@ end
 -- ============================================================================
 
 function CastbarModule:HandleCastStart_Simple(unitType, unit, isChanneling)
-    local spell, icon, startTime, endTime, notInterruptible
-    
+    local spell, icon, startTime, endTime, notInterruptible, castID
+
     if isChanneling then
         spell, _, _, icon, startTime, endTime, _, notInterruptible = UnitChannelInfo(unit)
+        castID = nil  -- channels carry no castID in 3.3.5a
     else
-        spell, _, _, icon, startTime, endTime, _, _, notInterruptible = UnitCastingInfo(unit)
+        spell, _, _, icon, startTime, endTime, _, castID, notInterruptible = UnitCastingInfo(unit)
     end
     
     if not spell then
@@ -1245,7 +1246,10 @@ function CastbarModule:HandleCastStart_Simple(unitType, unit, isChanneling)
     castbar.startTime = start
     castbar.endTime = finish
     castbar.spellName = spell
-    
+    -- castID is the authority for matching later FAILED / INTERRUPTED events to this exact
+    -- cast (Blizzard CastingBarFrame model). nil for channels, which have none in 3.3.5a.
+    castbar.castID = castID
+
     -- Cancel any active fade
     castbar.fadeOutEx = false
     if frames.container then
@@ -1496,13 +1500,11 @@ function CastbarModule:HandleCastStop_Simple(unitType, wasInterrupted, isChannel
     end
 end
 
-function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell)
-    -- UNIT_SPELLCAST_FAILED fires in three cases:
-    --   1) A spell failed to START (pressed another ability while casting) → ignore
-    --   2) A re-press of the spell being cast was rejected (macro spam) → ignore
-    --   3) The current cast was externally interrupted (CC/kick on target) → show "Failed"
-    -- Case 2 carries the SAME spell name as the tracked cast, so the spell name alone
-    -- cannot tell it apart from case 3. Ask the engine instead: see below.
+function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell, eventRank, eventCastID)
+    -- UNIT_SPELLCAST_FAILED fires for several reasons: a spell that failed to start, a
+    -- re-press rejected mid-cast, another macro spell failing, or the tracked cast being
+    -- interrupted. Case "re-press" carries the SAME spell name as the tracked cast, so the
+    -- name alone cannot tell it apart. castID can: Blizzard's own cast bar matches on it.
     local frames = self.frames[unitType]
     if not frames or not frames.castbar then return end
     local castbar = frames.castbar
@@ -1518,17 +1520,16 @@ function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell)
         end
     end
 
-    -- The engine is the authority, not the spell name. If it still reports an active cast,
-    -- the cast we track is alive and this event belongs to something else: a re-press
-    -- rejected while already casting (same spell name, defeats the check below), or another
-    -- spell of the same macro. A genuine failure clears the cast first, so a real one still
-    -- gets through.
-    if UnitCastingInfo(unit) or UnitChannelInfo(unit) then
-        return
-    end
-
-    -- If the event spell doesn't match our tracked cast, it's a queued spell failure
-    if eventSpell and castbar.spellName and eventSpell ~= castbar.spellName then
+    -- castID is the authority, not the spell name. A rejected re-press carries the SAME name
+    -- as the tracked cast but a DIFFERENT castID; another macro spell (e.g. Auto Shot while
+    -- moving) has its own castID too. Both are ignored. A genuine failure/interrupt of the
+    -- tracked cast carries its castID, so it still gets through. Channels have no castID in
+    -- 3.3.5a and fall back to the spell-name guard.
+    if castbar.castID then
+        if eventCastID ~= castbar.castID then
+            return
+        end
+    elseif eventSpell and castbar.spellName and eventSpell ~= castbar.spellName then
         return
     end
 
@@ -1537,21 +1538,19 @@ end
 
 -- UNIT_SPELLCAST_INTERRUPTED used to be dispatched straight to
 -- HandleCastStop_Simple(unitType, true) with no verification, so an interruption belonging
--- to ANOTHER spell wiped the bar of the cast in progress. Verify it the same way
+-- to ANOTHER spell wiped the bar of the cast in progress. Verify castID the same way
 -- HandleCastFailed_Simple does before acting on it.
-function CastbarModule:HandleCastInterrupted_Simple(unitType, eventSpell, isChannel)
+function CastbarModule:HandleCastInterrupted_Simple(unitType, isChannel, eventSpell, eventRank, eventCastID)
     local frames = self.frames[unitType]
     if not frames or not frames.castbar then return end
     local castbar = frames.castbar
     if not (castbar.castingEx or castbar.channelingEx) then return end
 
-    local unit = (unitType == "player") and "player" or unitType
-
-    if UnitCastingInfo(unit) or UnitChannelInfo(unit) then
-        return
-    end
-
-    if eventSpell and castbar.spellName and eventSpell ~= castbar.spellName then
+    if castbar.castID then
+        if eventCastID ~= castbar.castID then
+            return
+        end
+    elseif eventSpell and castbar.spellName and eventSpell ~= castbar.spellName then
         return
     end
 
@@ -2047,9 +2046,9 @@ function CastbarModule:HandleCastingEvent(event, unit, ...)
     elseif event == 'UNIT_SPELLCAST_FAILED' then
         self:HandleCastFailed_Simple(unitType, ...)
     elseif event == 'UNIT_SPELLCAST_INTERRUPTED' then
-        self:HandleCastInterrupted_Simple(unitType, select(1, ...), false)
+        self:HandleCastInterrupted_Simple(unitType, false, ...)
     elseif event == 'UNIT_SPELLCAST_CHANNEL_INTERRUPTED' then
-        self:HandleCastInterrupted_Simple(unitType, select(1, ...), true)
+        self:HandleCastInterrupted_Simple(unitType, true, ...)
     elseif event == 'UNIT_SPELLCAST_DELAYED' or event == 'UNIT_SPELLCAST_CHANNEL_UPDATE' then
         self:HandleCastDelayed_Simple(unitType, unit)
     elseif event == 'UNIT_SPELLCAST_NOT_INTERRUPTIBLE' then

--- a/DragonUI/modules/castbar.lua
+++ b/DragonUI/modules/castbar.lua
@@ -1497,11 +1497,12 @@ function CastbarModule:HandleCastStop_Simple(unitType, wasInterrupted, isChannel
 end
 
 function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell)
-    -- UNIT_SPELLCAST_FAILED fires in two cases:
+    -- UNIT_SPELLCAST_FAILED fires in three cases:
     --   1) A spell failed to START (pressed another ability while casting) → ignore
-    --   2) The current cast was externally interrupted (CC/kick on target) → show "Failed"
-    -- Distinguish by comparing the event's spell name with the tracked cast:
-    --   same spell = real interruption; different spell = queued spell failure.
+    --   2) A re-press of the spell being cast was rejected (macro spam) → ignore
+    --   3) The current cast was externally interrupted (CC/kick on target) → show "Failed"
+    -- Case 2 carries the SAME spell name as the tracked cast, so the spell name alone
+    -- cannot tell it apart from case 3. Ask the engine instead: see below.
     local frames = self.frames[unitType]
     if not frames or not frames.castbar then return end
     local castbar = frames.castbar
@@ -1517,12 +1518,44 @@ function CastbarModule:HandleCastFailed_Simple(unitType, eventSpell)
         end
     end
 
+    -- The engine is the authority, not the spell name. If it still reports an active cast,
+    -- the cast we track is alive and this event belongs to something else: a re-press
+    -- rejected while already casting (same spell name, defeats the check below), or another
+    -- spell of the same macro. A genuine failure clears the cast first, so a real one still
+    -- gets through.
+    if UnitCastingInfo(unit) or UnitChannelInfo(unit) then
+        return
+    end
+
     -- If the event spell doesn't match our tracked cast, it's a queued spell failure
     if eventSpell and castbar.spellName and eventSpell ~= castbar.spellName then
         return
     end
 
     self:HandleCastStop_Simple(unitType, true, nil, FAILED)
+end
+
+-- UNIT_SPELLCAST_INTERRUPTED used to be dispatched straight to
+-- HandleCastStop_Simple(unitType, true) with no verification, so an interruption belonging
+-- to ANOTHER spell wiped the bar of the cast in progress. Verify it the same way
+-- HandleCastFailed_Simple does before acting on it.
+function CastbarModule:HandleCastInterrupted_Simple(unitType, eventSpell, isChannel)
+    local frames = self.frames[unitType]
+    if not frames or not frames.castbar then return end
+    local castbar = frames.castbar
+    if not (castbar.castingEx or castbar.channelingEx) then return end
+
+    local unit = (unitType == "player") and "player" or unitType
+
+    if UnitCastingInfo(unit) or UnitChannelInfo(unit) then
+        return
+    end
+
+    if eventSpell and castbar.spellName and eventSpell ~= castbar.spellName then
+        return
+    end
+
+    self:HandleCastStop_Simple(unitType, true, isChannel)
 end
 
 function CastbarModule:HandleCastDelayed_Simple(unitType, unit)
@@ -2014,9 +2047,9 @@ function CastbarModule:HandleCastingEvent(event, unit, ...)
     elseif event == 'UNIT_SPELLCAST_FAILED' then
         self:HandleCastFailed_Simple(unitType, ...)
     elseif event == 'UNIT_SPELLCAST_INTERRUPTED' then
-        self:HandleCastStop_Simple(unitType, true)
+        self:HandleCastInterrupted_Simple(unitType, select(1, ...), false)
     elseif event == 'UNIT_SPELLCAST_CHANNEL_INTERRUPTED' then
-        self:HandleCastStop_Simple(unitType, true)
+        self:HandleCastInterrupted_Simple(unitType, select(1, ...), true)
     elseif event == 'UNIT_SPELLCAST_DELAYED' or event == 'UNIT_SPELLCAST_CHANNEL_UPDATE' then
         self:HandleCastDelayed_Simple(unitType, unit)
     elseif event == 'UNIT_SPELLCAST_NOT_INTERRUPTIBLE' then


### PR DESCRIPTION
## Problem

Two paths let a cast event belonging to a **different spell**, or to a **rejected re-press of the same spell**, wipe or redden the cast bar of a cast that is still perfectly alive.

Symptoms, both reproducible:

1. The player cast bar disappears a few milliseconds after appearing.
2. The bar turns red with Failed while the cast is actually still running and about to succeed.

## Reproduction

Use a macro that casts a spell with a cast time, followed by a second spell that will fail:

```
#showtooltip <spell with a cast time>
/cast <spell with a cast time>
/cast Auto Shot
```

Keep moving and spam the macro. Auto Shot cannot fire while moving, so it fails and is interrupted continuously.

## Root cause

1. `UNIT_SPELLCAST_INTERRUPTED` was dispatched straight to `HandleCastStop_Simple` with no verification, so any interrupt on the unit killed the bar.
2. Matching FAILED events by spell name alone is not enough: a rejected re-press carries the **same name** as the running cast, so the old guard still painted Failed.

## Fix

Match Blizzard `CastingBarFrame`: store `castID` from `UnitCastingInfo` on cast start, and only honor `UNIT_SPELLCAST_FAILED` / `UNIT_SPELLCAST_INTERRUPTED` when the event `castID` matches the tracked cast.

- Channels have no `castID` in 3.3.5a → keep the existing spell-name / `UnitChannelInfo` fallback.
- `INTERRUPTED` goes through a dedicated handler gated on `castID` (same model as FAILED).

## Testing

- [x] Bar stays for the full cast (macro + Auto Shot, moving, spammed)
- [x] No false red Failed
- [x] Escape cancel still correct
- [ ] Real interrupt (kick/silence) — logic matches FrameXML; worth a quick confirm in a group
