### PR TITLE
feat(locales): add UI language override via General tab dropdown

### DIFF
--- a/DragonUI/DragonUI.toc
+++ b/DragonUI/DragonUI.toc
@@ -18,6 +18,7 @@ libs\AceBucket-3.0\AceBucket-3.0.xml
 libs\AceHook-3.0\AceHook-3.0.xml
 libs\AceDB-3.0\AceDB-3.0.xml
 libs\AceLocale-3.0\AceLocale-3.0.xml
+libs\AceLocale-3.0\AceLocale-3.0-DragonUI.lua
 libs\AceConsole-3.0\AceConsole-3.0.xml
 libs\AceComm-3.0\AceComm-3.0.xml
 libs\AceTab-3.0\AceTab-3.0.xml

--- a/DragonUI/Locales/Load_Locales.xml
+++ b/DragonUI/Locales/Load_Locales.xml
@@ -13,4 +13,8 @@
 	<Script file="zhCN.lua"/>
 	<Script file="zhTW.lua"/>
 	<Script file="koKR.lua"/>
+
+	<!-- Locale override bootstrap (defines addon.GetActiveLocale, must load after
+	     the AceLocale fork in the TOC but before DragonUI.xml/config.lua) -->
+	<Script file="locale_override.lua"/>
 </Ui>

--- a/DragonUI/Locales/deDE.lua
+++ b/DragonUI/Locales/deDE.lua
@@ -11,7 +11,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "deDE")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "deDE")
 if not L then return end
 
 -- ============================================================================

--- a/DragonUI/Locales/enUS.lua
+++ b/DragonUI/Locales/enUS.lua
@@ -11,7 +11,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "enUS", true)
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "enUS", true)
 if not L then return end
 
 -- ============================================================================

--- a/DragonUI/Locales/esES.lua
+++ b/DragonUI/Locales/esES.lua
@@ -11,7 +11,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "esES")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "esES")
 if not L then return end
 
 -- ============================================================================

--- a/DragonUI/Locales/esMX.lua
+++ b/DragonUI/Locales/esMX.lua
@@ -11,7 +11,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "esMX")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "esMX")
 if not L then return end
 
 -- ============================================================================

--- a/DragonUI/Locales/frFR.lua
+++ b/DragonUI/Locales/frFR.lua
@@ -10,7 +10,7 @@
  - Keep color codes |cff...|r outside of L[] strings
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "frFR")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "frFR")
 if not L then return end
 
 -- Example:

--- a/DragonUI/Locales/koKR.lua
+++ b/DragonUI/Locales/koKR.lua
@@ -11,7 +11,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "koKR")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "koKR")
 if not L then return end
 
 -- ============================================================================

--- a/DragonUI/Locales/locale_override.lua
+++ b/DragonUI/Locales/locale_override.lua
@@ -1,0 +1,47 @@
+--[[
+================================================================================
+DragonUI - Locale Override Bootstrap
+================================================================================
+Reads the user's locale preference from the DragonUIDB SavedVariable BEFORE
+AceDB:New() runs (AceDB initializes in core.lua:OnInitialize, which fires on
+PLAYER_LOGIN — long after the locale files have been evaluated).
+
+The override is stored in the AceDB **global** namespace
+(_G.DragonUIDB.global.locale), so it persists across characters and profiles
+and is available in raw SavedVar form whenever this file is evaluated.
+
+Resolution order:
+  1. _G.DragonUIDB.global.locale  (user override from the General tab dropdown)
+  2. GetLocale()                  (client language, "enGB" normalised to "enUS")
+
+A value of "auto" (or nil/empty) means "follow the client language".
+================================================================================
+]]
+
+local addon = select(2, ...)
+if not addon then return end
+
+local CLIENT_LOCALE = GetLocale()
+if CLIENT_LOCALE == "enGB" then
+    CLIENT_LOCALE = "enUS"
+end
+
+-- Set of locales DragonUI ships translations for.
+local SUPPORTED = {
+    enUS = true, esES = true, esMX = true, ptBR = true,
+    deDE = true, frFR = true, ruRU = true,
+    zhCN = true, zhTW = true, koKR = true,
+}
+
+function addon.GetActiveLocale()
+    local sv = _G.DragonUIDB
+    local pref = sv and sv.global and sv.global.locale
+    if type(pref) == "string" and pref ~= "" and pref ~= "auto" and SUPPORTED[pref] then
+        return pref
+    end
+    return CLIENT_LOCALE
+end
+
+-- Exposed for the options panel / dropdown UI.
+addon.SUPPORTED_LOCALES = SUPPORTED
+addon.CLIENT_LOCALE = CLIENT_LOCALE

--- a/DragonUI/Locales/ptBR.lua
+++ b/DragonUI/Locales/ptBR.lua
@@ -10,7 +10,7 @@
  - Keep color codes |cff...|r outside of L[] strings
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "ptBR")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "ptBR")
 if not L then return end
 
 -- Example:

--- a/DragonUI/Locales/ruRU.lua
+++ b/DragonUI/Locales/ruRU.lua
@@ -11,7 +11,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "ruRU")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "ruRU")
 if not L then return end
 
 -- ============================================================================

--- a/DragonUI/Locales/zhCN.lua
+++ b/DragonUI/Locales/zhCN.lua
@@ -11,7 +11,7 @@ DragonUI - 简体中文本地化文件
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "zhCN")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "zhCN")
 if not L then return end
 
 -- ============================================================================

--- a/DragonUI/Locales/zhTW.lua
+++ b/DragonUI/Locales/zhTW.lua
@@ -10,7 +10,7 @@
  - Keep color codes |cff...|r outside of L[] strings
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI", "zhTW")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "zhTW")
 if not L then return end
 
 -- Example:

--- a/DragonUI/config.lua
+++ b/DragonUI/config.lua
@@ -7,7 +7,10 @@
 local addon = select(2,...);
 
 -- Localization (must load before any core/ file that references addon.L)
-addon.L = LibStub("AceLocale-3.0"):GetLocale("DragonUI")
+-- Uses the DragonUI AceLocale fork: all locales are always registered, and the
+-- user's preferred locale (General tab dropdown) is selected via GetActiveLocale().
+addon.L = LibStub("AceLocale-3.0-DragonUI"):GetLocale("DragonUI", addon.GetActiveLocale())
+addon.LO = addon.L -- Backwards-compatible alias used by options panels
 
 addon._dir = [[Interface\AddOns\DragonUI\Textures\]];
 

--- a/DragonUI/database.lua
+++ b/DragonUI/database.lua
@@ -11,6 +11,7 @@ local _arialn = addon.Fonts and addon.Fonts.ARIALN or "Fonts\\ARIALN.TTF"
 
 local defaults = {
     global = {
+        locale = "auto", -- UI language override; "auto" follows the client locale
         bagsterCache = {}, -- Per-character bank snapshot (realm|name keys); used by bagster module
         characterMoney = {}, -- Gold per character (realm|name keys); used by the altmoney tooltip
         questLootLearned = {}, -- Learned quest loot sources for nameplates: [mobName] = {objectiveText=true}

--- a/DragonUI/libs/AceLocale-3.0/AceLocale-3.0-DragonUI.lua
+++ b/DragonUI/libs/AceLocale-3.0/AceLocale-3.0-DragonUI.lua
@@ -1,0 +1,149 @@
+--- **AceLocale-3.0-DragonUI** manages localization in addons, allowing for multiple locale to be registered with fallback to the base locale for untranslated strings.
+-- Fork of AceLocale-3.0 (ElvUI-style): NewLocale always loads every locale (no GAME_LOCALE gating),
+-- and GetLocale accepts a `locale` arg to pick the active locale. Lets users override the client
+-- locale at runtime via a dropdown + ReloadUI.
+-- @class file
+-- @name AceLocale-3.0-DragonUI
+-- @release forked from AceLocale-3.0.lua r895
+local MAJOR,MINOR = "AceLocale-3.0-DragonUI", 1
+
+local AceLocale, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceLocale then return end -- no upgrade needed
+
+-- Lua APIs
+local assert, tostring, error, getmetatable = assert, tostring, error, getmetatable
+local setmetatable, rawset, rawget = setmetatable, rawset, rawget
+
+-- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
+-- List them here for Mikk's FindGlobals script
+-- GLOBALS: GAME_LOCALE, geterrorhandler
+
+local gameLocale = GetLocale()
+if gameLocale == "enGB" then
+	gameLocale = "enUS"
+end
+
+AceLocale.apps = AceLocale.apps or {}          -- array of ["AppName"]=localetableref
+AceLocale.appnames = AceLocale.appnames or {}  -- array of [localetableref]="AppName"
+
+-- This metatable is used on all tables returned from GetLocale
+local readmeta = {
+	__index = function(self, key) -- requesting totally unknown entries: fire off a nonbreaking error and return key
+		rawset(self, key, key)      -- only need to see the warning once, really
+		geterrorhandler()(MAJOR..": "..tostring(AceLocale.appnames[self])..": Missing entry for '"..tostring(key).."'")
+		return key
+	end
+}
+
+-- This metatable is used on all tables returned from GetLocale if the silent flag is true, it does not issue a warning on unknown keys
+local readmetasilent = {
+	__index = function(self, key) -- requesting totally unknown entries: return key
+		rawset(self, key, key)      -- only need to invoke this function once
+		return key
+	end
+}
+
+-- Remember the locale table being registered right now (it gets set by :NewLocale())
+-- NOTE: Do never try to register 2 locale tables at once and mix their definition.
+local registering
+
+-- local assert false function
+local assertfalse = function() assert(false) end
+
+-- This metatable proxy is used when registering nondefault locales
+local writeproxy = setmetatable({}, {
+	__newindex = function(self, key, value)
+		rawset(registering, key, value == true and key or value) -- assigning values: replace 'true' with key string
+	end,
+	__index = assertfalse
+})
+
+-- This metatable proxy is used when registering the default locale. 
+-- It refuses to overwrite existing values
+-- Reason 1: Allows loading locales in any order
+-- Reason 2: If 2 modules have the same string, but only the first one to be 
+--           loaded has a translation for the current locale, the translation
+--           doesn't get overwritten.
+--
+local writedefaultproxy = setmetatable({}, {
+	__newindex = function(self, key, value)
+		if not rawget(registering, key) then
+			rawset(registering, key, value == true and key or value)
+		end
+	end,
+	__index = assertfalse
+})
+
+--- Register a new locale (or extend an existing one) for the specified application.
+-- :NewLocale will return a table you can fill your locale into, or nil if the locale isn't needed for the players
+-- game locale.
+-- @paramsig application, locale[, isDefault[, silent]]
+-- @param application Unique name of addon / module
+-- @param locale Name of the locale to register, e.g. "enUS", "deDE", etc.
+-- @param isDefault If this is the default locale being registered (your addon is written in this language, generally enUS)
+-- @param silent If true, the locale will not issue warnings for missing keys. Must be set on the first locale registered.
+-- @usage
+-- -- enUS.lua
+-- local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "enUS", true)
+-- L["string1"] = true
+--
+-- -- deDE.lua
+-- local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI", "deDE")
+-- if not L then return end
+-- L["string1"] = "Zeichenkette1"
+-- @return Locale Table to add localizations to, or nil if the current locale is not required.
+function AceLocale:NewLocale(application, locale, isDefault, silent)
+	local app = AceLocale.apps[application]
+
+	if silent and app and getmetatable(app) ~= readmetasilent then
+		geterrorhandler()("Usage: NewLocale(application, locale[, isDefault[, silent]]): 'silent' must be specified for the first locale registered")
+	end
+
+	if not app then
+		app = setmetatable({}, silent and readmetasilent or readmeta)
+		AceLocale.apps[application] = app
+		AceLocale.appnames[app] = application
+	end
+
+	-- DragonUI block (ElvUI-style): always register every locale, no GAME_LOCALE gating.
+	-- NOTE: use rawget (not app[locale]) — the app table carries the noisy readmeta
+	-- metatable, so indexing an unregistered locale would fire "Missing entry" errors.
+	if type(rawget(app, locale)) ~= "table" then
+		app[locale] = setmetatable({}, readmetasilent)
+	end
+
+	registering = app[locale] -- remember globally for writeproxy and writedefaultproxy
+	-- end block
+
+	if isDefault then
+		return writedefaultproxy
+	end
+
+	return writeproxy
+end
+
+--- Returns localizations for the current locale (or default locale if translations are missing).
+-- Errors if nothing is registered (spank developer, not just a missing translation)
+-- @param application Unique name of addon / module
+-- @param locale Optional locale name (e.g. "esES"). Falls back to the client gameLocale if omitted or not registered.
+-- @param silent If true, the locale is optional, silently return nil if it's not found (defaults to false, optional)
+-- @return The locale table for the requested (or current) language.
+--- Modified by DragonUI to add `locale` as second arg
+function AceLocale:GetLocale(application, locale, silent)
+	if type(locale) == "boolean" then
+		silent = locale
+		locale = gameLocale
+	end
+
+	if not silent and not AceLocale.apps[application] then
+		error("Usage: GetLocale(application[, locale[, silent]]): 'application' - No locales registered for '"..tostring(application).."'", 2)
+	end
+
+	local app = AceLocale.apps[application]
+	local tbl = app and rawget(app, locale)
+	if type(tbl) ~= "table" then
+		tbl = app and rawget(app, gameLocale)
+	end
+	return tbl
+end

--- a/DragonUI_Options/Locales/deDE.lua
+++ b/DragonUI_Options/Locales/deDE.lua
@@ -12,7 +12,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "deDE")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "deDE")
 if not L then return end
 
 -- ============================================================================
@@ -43,6 +43,9 @@ L["Switch micro menu icons between colored and grayscale style."] = "Mikro-Menü
 L["About"] = "Über"
 L["Bringing the retail WoW look to 3.3.5a, inspired by Dragonflight UI."] = "Der Retail-WoW-Look für 3.3.5a, inspiriert von Dragonflight UI."
 L["Created and maintained by Neticsoul, with community contributions."] = "Erstellt und gepflegt von Neticsoul, mit Beiträgen der Community."
+L["Language"] = "Sprache"
+L["Choose the language used by the DragonUI interface."] = "Wähle die Sprache für die DragonUI-Oberfläche."
+L["Follow the client language"] = "Clientsprache übernehmen"
 
 L["Commands: /dragonui, /dui, /pi — /dragonui edit (editor) — /dragonui help"] = "Befehle: /dragonui, /dui, /pi — /dragonui edit (Editor) — /dragonui help"
 L["GitHub (select and Ctrl+C to copy):"] = "GitHub (markieren und Strg+C zum Kopieren):"

--- a/DragonUI_Options/Locales/enUS.lua
+++ b/DragonUI_Options/Locales/enUS.lua
@@ -12,7 +12,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "enUS", true)
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "enUS", true)
 if not L then return end
 
 -- ============================================================================
@@ -44,6 +44,11 @@ L["Switch micro menu icons between colored and grayscale style."] = true
 L["About"] = true
 L["Bringing the retail WoW look to 3.3.5a, inspired by Dragonflight UI."] = true
 L["Created and maintained by Neticsoul, with community contributions."] = true
+
+-- Language
+L["Language"] = true
+L["Choose the language used by the DragonUI interface."] = true
+L["Follow the client language"] = true
 
 L["Commands: /dragonui, /dui, /pi \226\128\148 /dragonui edit (editor) \226\128\148 /dragonui help"] = true
 L["GitHub (select and Ctrl+C to copy):"] = true

--- a/DragonUI_Options/Locales/esES.lua
+++ b/DragonUI_Options/Locales/esES.lua
@@ -12,7 +12,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "esES")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "esES")
 if not L then return end
 
 -- ============================================================================
@@ -43,6 +43,9 @@ L["Switch micro menu icons between colored and grayscale style."] = "Alternar lo
 L["About"] = "Acerca de"
 L["Bringing the retail WoW look to 3.3.5a, inspired by Dragonflight UI."] = "Trayendo el aspecto del WoW retail a 3.3.5a, inspirado en Dragonflight UI."
 L["Created and maintained by Neticsoul, with community contributions."] = "Creado y mantenido por Neticsoul, con contribuciones de la comunidad."
+L["Language"] = "Idioma"
+L["Choose the language used by the DragonUI interface."] = "Elige el idioma que usará la interfaz de DragonUI."
+L["Follow the client language"] = "Seguir el idioma del cliente"
 
 L["Commands: /dragonui, /dui, /pi \226\128\148 /dragonui edit (editor) \226\128\148 /dragonui help"] = "Comandos: /dragonui, /dui, /pi \226\128\148 /dragonui edit (editor) \226\128\148 /dragonui help"
 L["GitHub (select and Ctrl+C to copy):"] = "GitHub (selecciona y Ctrl+C para copiar):"

--- a/DragonUI_Options/Locales/esMX.lua
+++ b/DragonUI_Options/Locales/esMX.lua
@@ -12,7 +12,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "esMX")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "esMX")
 if not L then return end
 
 -- ============================================================================
@@ -43,6 +43,9 @@ L["Switch micro menu icons between colored and grayscale style."] = "Alternar lo
 L["About"] = "Acerca de"
 L["Bringing the retail WoW look to 3.3.5a, inspired by Dragonflight UI."] = "Trayendo el aspecto del WoW retail a 3.3.5a, inspirado en Dragonflight UI."
 L["Created and maintained by Neticsoul, with community contributions."] = "Creado y mantenido por Neticsoul, con contribuciones de la comunidad."
+L["Language"] = "Idioma"
+L["Choose the language used by the DragonUI interface."] = "Elige el idioma que usará la interfaz de DragonUI."
+L["Follow the client language"] = "Seguir el idioma del cliente"
 
 L["Commands: /dragonui, /dui, /pi \226\128\148 /dragonui edit (editor) \226\128\148 /dragonui help"] = "Comandos: /dragonui, /dui, /pi \226\128\148 /dragonui edit (editor) \226\128\148 /dragonui help"
 L["GitHub (select and Ctrl+C to copy):"] = "GitHub (selecciona y Ctrl+C para copiar):"

--- a/DragonUI_Options/Locales/frFR.lua
+++ b/DragonUI_Options/Locales/frFR.lua
@@ -9,7 +9,7 @@
  - Keep color codes |cff...|r outside of L[] strings
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "frFR")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "frFR")
 if not L then return end
 
 L["Collector"] = "Collecteur"
@@ -721,6 +721,10 @@ L["Square"] = "Carré"
 L["Out of Range Color"] = "Couleur hors de portée"
 L["Not Enough Mana Color"] = "Couleur mana insuffisant"
 
+-- Language
+L["Language"] = "Langue"
+L["Choose the language used by the DragonUI interface."] = "Choisissez la langue utilisée par l'interface de DragonUI."
+L["Follow the client language"] = "Suivre la langue du client"
 -- Quest nameplate icons (loot providers + Questie coexistence)
 L["Resolve By Name"] = "Résoudre par nom"
 L["Match plate names to your active objectives so icons show on every plate without awesome_wotlk. Kill objectives work on their own; loot needs a quest addon below."] = "Associe les noms des plaques à vos objectifs actifs pour afficher les icônes sur chaque plaque sans awesome_wotlk. Les objectifs de meurtre fonctionnent seuls ; le butin nécessite un addon de quête (ci-dessous)."

--- a/DragonUI_Options/Locales/koKR.lua
+++ b/DragonUI_Options/Locales/koKR.lua
@@ -12,7 +12,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "koKR")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "koKR")
 if not L then return end
 
 L["Collector"] = "수집기"
@@ -53,6 +53,9 @@ L["Switch micro menu icons between colored and grayscale style."] = "마이크�
 L["About"] = "정보"
 L["Bringing the retail WoW look to 3.3.5a, inspired by Dragonflight UI."] = "Dragonflight UI에서 영감을 받아 3.3.5a에 리테일 WoW 느낌을 구현합니다."
 L["Created and maintained by Neticsoul, with community contributions."] = "Neticsoul이 제작 및 유지하며, 커뮤니티가 기여합니다."
+L["Language"] = "언어"
+L["Choose the language used by the DragonUI interface."] = "DragonUI 인터페이스에서 사용할 언어를 선택하세요."
+L["Follow the client language"] = "클라이언트 언어 따르기"
 
 L["Commands: /dragonui, /dui, /pi — /dragonui edit (editor) — /dragonui help"] = "명령어: /dragonui, /dui, /pi — /dragonui edit (편집) — /dragonui help"
 L["GitHub (select and Ctrl+C to copy):"] = "GitHub (선택 후 Ctrl+C로 복사):"

--- a/DragonUI_Options/Locales/ptBR.lua
+++ b/DragonUI_Options/Locales/ptBR.lua
@@ -9,7 +9,7 @@
  - Keep color codes |cff...|r outside of L[] strings
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "ptBR")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "ptBR")
 if not L then return end
 
 L["Collector"] = "Coletor"
@@ -715,6 +715,10 @@ L["Square"] = "Quadrado"
 L["Out of Range Color"] = "Cor fora de alcance"
 L["Not Enough Mana Color"] = "Cor de mana insuficiente"
 
+-- Language
+L["Language"] = "Idioma"
+L["Choose the language used by the DragonUI interface."] = "Escolha o idioma usado pela interface do DragonUI."
+L["Follow the client language"] = "Seguir o idioma do cliente"
 -- Quest nameplate icons (loot providers + Questie coexistence)
 L["Resolve By Name"] = "Resolver por nome"
 L["Match plate names to your active objectives so icons show on every plate without awesome_wotlk. Kill objectives work on their own; loot needs a quest addon below."] = "Combina os nomes das placas com seus objetivos ativos para mostrar ícones em todas as placas sem o awesome_wotlk. Objetivos de matar funcionam sozinhos; saque precisa de um addon de missões (abaixo)."

--- a/DragonUI_Options/Locales/ruRU.lua
+++ b/DragonUI_Options/Locales/ruRU.lua
@@ -12,7 +12,7 @@ When adding new strings:
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "ruRU")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "ruRU")
 if not L then return end
 
 L["Collector"] = "Коллектор"
@@ -48,6 +48,9 @@ L["Switch micro menu icons between colored and grayscale style."] = "Перек�
 L["About"] = "О программе"
 L["Bringing the retail WoW look to 3.3.5a, inspired by Dragonflight UI."] = "Вдохновлённый Dragonflight UI внешний вид актуального WoW, перенесённый в 3.3.5a."
 L["Created and maintained by Neticsoul, with community contributions."] = "Создано и поддерживается Neticsoul при участии сообщества."
+L["Language"] = "Язык"
+L["Choose the language used by the DragonUI interface."] = "Выберите язык интерфейса DragonUI."
+L["Follow the client language"] = "Следовать языку клиента"
 
 L["Commands: /dragonui, /dui, /pi — /dragonui edit (editor) — /dragonui help"] = "Команды: /dragonui, /dui, /pi — /dragonui edit (редактор) — /dragonui help"
 L["GitHub (select and Ctrl+C to copy):"] = "GitHub (выделите и Ctrl+C для копирования):"

--- a/DragonUI_Options/Locales/zhCN.lua
+++ b/DragonUI_Options/Locales/zhCN.lua
@@ -11,7 +11,7 @@ DragonUI_Options - 简体中文本地化文件
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "zhCN")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "zhCN")
 if not L then return end
 
 L["Collector"] = "收集器"
@@ -47,6 +47,9 @@ L["Switch micro menu icons between colored and grayscale style."] = "在彩色�
 L["About"] = "关于"
 L["Bringing the retail WoW look to 3.3.5a, inspired by Dragonflight UI."] = "受巨龙时代UI启发，为3.3.5a版本带来正式服《魔兽世界》的外观。"
 L["Created and maintained by Neticsoul, with community contributions."] = "由Neticsoul创建和维护，并有社区贡献。"
+L["Language"] = "语言"
+L["Choose the language used by the DragonUI interface."] = "选择DragonUI界面使用的语言。"
+L["Follow the client language"] = "跟随客户端语言"
 
 L["Commands: /dragonui, /dui, /pi — /dragonui edit (editor) — /dragonui help"] = "命令：/dragonui, /dui, /pi — /dragonui edit (编辑) — /dragonui help"
 L["GitHub (select and Ctrl+C to copy):"] = "GitHub (选中后按Ctrl+C复制)："

--- a/DragonUI_Options/Locales/zhTW.lua
+++ b/DragonUI_Options/Locales/zhTW.lua
@@ -11,7 +11,7 @@ DragonUI_Options - 繁體中文本地化檔案
 ================================================================================
 ]]
 
-local L = LibStub("AceLocale-3.0"):NewLocale("DragonUI_Options", "zhTW")
+local L = LibStub("AceLocale-3.0-DragonUI"):NewLocale("DragonUI_Options", "zhTW")
 if not L then return end
 
 L["Collector"] = "收集器"
@@ -47,6 +47,9 @@ L["Switch micro menu icons between colored and grayscale style."] = "在彩色�
 L["About"] = "關於"
 L["Bringing the retail WoW look to 3.3.5a, inspired by Dragonflight UI."] = "受巨龍時代UI啟發，為3.3.5a版本帶來正式服《魔獸世界》的外觀。"
 L["Created and maintained by Neticsoul, with community contributions."] = "由Neticsoul建立和維護，並有社群貢獻。"
+L["Language"] = "語言"
+L["Choose the language used by the DragonUI interface."] = "選擇DragonUI介面使用的語言。"
+L["Follow the client language"] = "跟隨客戶端語言"
 
 L["Commands: /dragonui, /dui, /pi — /dragonui edit (editor) — /dragonui help"] = "命令：/dragonui, /dui, /pi — /dragonui edit (編輯) — /dragonui help"
 L["GitHub (select and Ctrl+C to copy):"] = "GitHub (選中後按Ctrl+C複製)："

--- a/DragonUI_Options/core.lua
+++ b/DragonUI_Options/core.lua
@@ -11,8 +11,9 @@ Based on ElvUI_OptionsUI pattern - accesses DragonUI addon via global.
 local addon = DragonUI
 
 -- Initialize localization before any fallback/error path uses it.
-local L = LibStub("AceLocale-3.0"):GetLocale("DragonUI")
-local LO = LibStub("AceLocale-3.0"):GetLocale("DragonUI_Options")
+local activeLocale = addon.GetActiveLocale and addon.GetActiveLocale()
+local L = LibStub("AceLocale-3.0-DragonUI"):GetLocale("DragonUI", activeLocale)
+local LO = LibStub("AceLocale-3.0-DragonUI"):GetLocale("DragonUI_Options", activeLocale)
 
 if not addon then
     print("|cFFFF0000[DragonUI_Options]|r " .. ((LO and LO["Error: DragonUI addon not found!"]) or "Error: DragonUI addon not found!"))

--- a/DragonUI_Options/panel/tab_general.lua
+++ b/DragonUI_Options/panel/tab_general.lua
@@ -388,6 +388,47 @@ local function BuildGeneralTab(scroll)
     C:AddSpacer(scroll)
 
     -- ====================================================================
+    -- LANGUAGE
+    -- ====================================================================
+    local language = C:AddSection(scroll, LO["Language"])
+
+    C:AddDescription(language, LO["Choose the language used by the DragonUI interface."])
+
+    local localeValues = {
+        auto = LO["Follow the client language"],
+        enUS = "English",
+        esES = "Español",
+        esMX = "Español (México)",
+        ptBR = "Português",
+        deDE = "Deutsch",
+        frFR = "Français",
+        ruRU = "Русский",
+        zhCN = "简体中文",
+        zhTW = "繁體中文",
+        koKR = "한국어",
+    }
+
+    C:AddDropdown(language, {
+        label = LO["Language"],
+        desc  = LO["Choose the language used by the DragonUI interface."],
+        values = localeValues,
+        getFunc = function()
+            return (addon.db and addon.db.global and addon.db.global.locale) or "auto"
+        end,
+        setFunc = function(value)
+            if addon.db and addon.db.global then
+                addon.db.global.locale = value
+            end
+        end,
+        callback = function()
+            StaticPopup_Show("DRAGONUI_RELOAD_UI")
+        end,
+        width = 200,
+    })
+
+    C:AddSpacer(scroll)
+
+    -- ====================================================================
     -- QUICK ACCESS
     -- ====================================================================
     local actions = C:AddSection(scroll, LO["Quick Actions"])


### PR DESCRIPTION
## Summary

This PR lets every player choose the language of the DragonUI interface regardless of their game client locale, adding a **Language** dropdown to the **General** tab of DragonUI Options.

Until now, DragonUI always used the locale of the game client (`GAME_LOCALE`). Players on clients that ship no translation — or who simply prefer another language — had no way to switch. This change fixes that: you pick a language, the UI reloads, and the entire interface (core + options panel) renders in your chosen language.

## Why this matters

- **Clients without a matching locale**: players on `enUS`/`enGB` clients (Ascension, private servers, etc.) previously had no way to use the existing translations — even though the addon ships 10 of them.
- **Preference over force**: the addon language no longer depends on the game client language; the player decides.
- **Auto by default**: the default is `auto`, which keeps the current behavior (follow the client) — nothing changes unless the player opts in.

## How it works

### 1. Fork of AceLocale (`AceLocale-3.0-DragonUI`)

Following the ElvUI pattern, a fork of AceLocale ships at `libs/AceLocale-3.0/AceLocale-3.0-DragonUI.lua`:

- `NewLocale` always registers every locale table, ignoring `GAME_LOCALE`, so a translation is available even when the client locale doesn't match.
- `GetLocale(application, locale, silent)` accepts the locale explicitly, with a fallback to the client locale.
- Existence checks use `rawget(app, locale)` instead of `app[locale]` to avoid the noisy `readmeta` metatable firing "Missing entry for 'X'" warnings on unregistered locales.
- The stock `AceLocale-3.0` is kept for other libraries that still load it (e.g. LibKeyBound).

### 2. `addon.GetActiveLocale()` — `DragonUI/Locales/locale_override.lua`

New file that computes which locale to use:

- Reads the stored preference from the AceDB **global** namespace (`DragonUIDB.global.locale`), so it works even before `AceDB:New()` runs in `config.lua`.
- Falls back to the client locale on first load (nothing saved yet → current behavior).
- Normalizes `enGB` → `enUS` and validates against the 10 supported locales.

### 3. Where the choice lives

`defaults.global.locale = "auto"` in `DragonUI/database.lua`. It's stored in **global**, not profile, because `config.lua` runs before profiles exist — it needs the raw value to build the correct `addon.L` table.

### 4. The UI — General tab

`DragonUI_Options/panel/tab_general.lua` gains a **Language** section with a dropdown:

- `auto` (follow the client) + the 10 supported locales, each shown in its native name (Español, Deutsch, Русский, 简体中文, …).
- Uses `getFunc`/`setFunc` bound to `addon.db.global.locale` (a `dbPath` won't work since the value is global, not per-profile).
- On change, it reuses the existing `DRAGONUI_RELOAD_UI` popup (`Reload Now` / `Not Now`), since the locale tables are loaded at addon load.

### 5. Locale migration

All **20 locale files** (10 core + 10 options) now register through the fork. The 3 new keys — `Language`, `Choose the language used by the DragonUI interface.`, `Follow the client language` — are translated into all 10 languages.

## Files changed

| File | Change |
|---|---|
| `libs/AceLocale-3.0/AceLocale-3.0-DragonUI.lua` | New: AceLocale fork (ElvUI-style, `rawget` fix) |
| `Locales/locale_override.lua` | New: `addon.GetActiveLocale()` + supported-locale validation |
| `config.lua` | Loads `addon.L` via the fork + `GetActiveLocale()` |
| `database.lua` | `defaults.global.locale = "auto"` |
| `DragonUI.toc` | Registers the fork after `AceLocale-3.0.xml` |
| `Locales/Load_Locales.xml` | Loads `locale_override.lua` last |
| `Locales/*.lua` (×10) | Migrated to the fork |
| `DragonUI_Options/core.lua` | Uses the fork + `GetActiveLocale()` |
| `panel/tab_general.lua` | Language dropdown + reload prompt |
| `DragonUI_Options/Locales/*.lua` (×10) | Migrated + 3 new keys translated |

## Verification

- All Lua files pass `luac5.1 -p`.
- Dropdown values resolve via `addon.L` in all 10 languages.
- No "Missing entry for 'X'" errors after the `rawget` fix.