### PR TITLE
fix(nameplates): stop cast bars leaking on headline plates

### DIFF
--- a/DragonUI/modules/nameplates/features/castbar.lua
+++ b/DragonUI/modules/nameplates/features/castbar.lua
@@ -200,6 +200,11 @@ function NP.castbar.BindNativeCastPlateIdentity(plateData)
 end
 
 function NP.castbar.OnNativeCastShown(plateData)
+    -- Headline plates are name only; stomp the native bar as the client shows it.
+    if NP.gather.IsHeadlineActive(plateData) then
+        NP.castbar.HideNativeCastVisual(plateData)
+        return
+    end
     ResetNativeCastTrack(plateData)
     NP.layout.EnsureMinaStack(plateData)
     local bar = plateData.minaCast
@@ -350,6 +355,10 @@ function NP.castbar.ShowInterruptedState(bar, plateData, isPartyBar)
         return
     end
     if bar._intHideAt then
+        return
+    end
+    -- Headline plates never show cast visuals, including the interrupted hold.
+    if NP.gather.IsHeadlineActive(plateData) then
         return
     end
 
@@ -894,8 +903,8 @@ function PartyRaidCastTracker:StartCast(unit, isChannel)
     local plateData = FindPlateForGroupUnit(unit)
     if not plateData or not plateData.minaPartyCast then return end
 
-    -- Headline mode shows only the name for party/raid plates: no cast bar.
-    if NP.gather.IsFriendlyNameOnlyActive(plateData) then return end
+    -- Headline mode shows only the name (players and friendly NPCs): no cast bar.
+    if NP.gather.IsHeadlineActive(plateData) then return end
 
     -- Plates resolved as target/focus already render the main castbar.
     local resolvedUnit = NP.identity.ResolvePlateUnit(plateData)
@@ -2166,6 +2175,9 @@ function NP.castbar.StartMonitorCast(plateData, sourceGUID, spellName, spellIcon
     if not IsOffTargetMonitorEnabled(cfg) then
         return false
     end
+    if NP.gather.IsHeadlineActive(plateData) then
+        return false
+    end
     if IsAggressiveCastMonitor(cfg) and sourceGUID then
         if not PlateMayReceiveMonitorCast(plateData, sourceGUID) then
             return false
@@ -2733,6 +2745,22 @@ function NP.castbar.SuppressNativeCastVisual(plateData)
     plateData._nativeCastSuppressed = true
 end
 
+-- Headline (name-only) plates carry no cast visuals at all: drop both addon bars
+-- past their interrupt/success fades and stomp the native bar the client draws.
+function NP.castbar.HidePlateCastVisualsForHeadline(plateData)
+    if not plateData then return end
+    -- Cleared first so the reset below cannot re-show an interrupted party bar.
+    PartyRaidCastTracker.activeCasts[plateData] = nil
+    NP.castbar.ResetPlateCastBar(plateData)
+    if plateData.minaCastSpark then plateData.minaCastSpark:Hide() end
+    if plateData.minaPartyCastSpark then plateData.minaPartyCastSpark:Hide() end
+    -- Otherwise the backup promotion in SyncCastBar can resurrect the bar.
+    plateData._monitorBackup = nil
+    activeTickPlates[plateData] = nil
+    -- Not SuppressNativeCastVisual: its one-shot flag would no-op on later casts.
+    NP.castbar.HideNativeCastVisual(plateData)
+end
+
 function NP.castbar.HidePlateCastBar(plateData, force)
     local bar = plateData.minaCast
     if not bar then
@@ -3291,6 +3319,11 @@ function NP.castbar.SyncCastBar(plateData)
     local src = plateData.castBar
     local bar = plateData.minaCast
     if not bar then return end
+
+    if NP.gather.IsHeadlineActive(plateData) then
+        NP.castbar.HidePlateCastVisualsForHeadline(plateData)
+        return
+    end
 
     if NP.gather.IsTotemIconOnlyActive(plateData) then
         NP.castbar.HidePlateCastBar(plateData)

--- a/DragonUI/modules/nameplates/features/castbar.lua
+++ b/DragonUI/modules/nameplates/features/castbar.lua
@@ -200,12 +200,14 @@ function NP.castbar.BindNativeCastPlateIdentity(plateData)
 end
 
 function NP.castbar.OnNativeCastShown(plateData)
+    -- Reset first: leaving headline mid-cast would otherwise read a stale max value
+    -- left by the previous cast on this recycled plate.
+    ResetNativeCastTrack(plateData)
     -- Headline plates are name only; stomp the native bar as the client shows it.
     if NP.gather.IsHeadlineActive(plateData) then
         NP.castbar.HideNativeCastVisual(plateData)
         return
     end
-    ResetNativeCastTrack(plateData)
     NP.layout.EnsureMinaStack(plateData)
     local bar = plateData.minaCast
     if bar then
@@ -980,7 +982,10 @@ function PartyRaidCastTracker:StopCast(unit, interrupted)
     local plateData = self:FindPlateForUnit(unit)
     if not plateData then return end
     local bar = plateData.minaPartyCast
-    if bar and (interrupted or ShouldInterruptPartyEarlyEnd(unit, bar)) then
+    -- ShowInterruptedState no-ops under headline, so fall through to HideBar instead
+    -- of clearing activeCasts and leaving the bar up until the next refresh.
+    if bar and (interrupted or ShouldInterruptPartyEarlyEnd(unit, bar))
+        and not NP.gather.IsHeadlineActive(plateData) then
         NP.castbar.ShowInterruptedState(bar, plateData, true)
         self.activeCasts[plateData] = nil
         return
@@ -3317,13 +3322,15 @@ end
 function NP.castbar.SyncCastBar(plateData)
     local cfg = NP.config.GetCfg()
     local src = plateData.castBar
-    local bar = plateData.minaCast
-    if not bar then return end
 
+    -- Above the bar check: a headline plate with no minaCast yet still needs the stomp.
     if NP.gather.IsHeadlineActive(plateData) then
         NP.castbar.HidePlateCastVisualsForHeadline(plateData)
         return
     end
+
+    local bar = plateData.minaCast
+    if not bar then return end
 
     if NP.gather.IsTotemIconOnlyActive(plateData) then
         NP.castbar.HidePlateCastBar(plateData)
@@ -3579,6 +3586,12 @@ end
 -- Native castbar hook handler (lifecycle)
 
 function NP.castbar.OnNativeCastValueChanged(plateData, val)
+    -- Fires every frame for the whole cast; headline plates only need the native
+    -- stomp re-asserted, not a full reset pass per plate per frame.
+    if NP.gather.IsHeadlineActive(plateData) then
+        NP.castbar.HideNativeCastVisual(plateData)
+        return
+    end
     val = tonumber(val)
     if val and val >= 0.002 then
         UpdateNativeCastTrack(plateData, val)

--- a/DragonUI/modules/nameplates/pipeline/gather.lua
+++ b/DragonUI/modules/nameplates/pipeline/gather.lua
@@ -1072,13 +1072,15 @@ function NP.gather.RefreshPlateTargetState(plateData, reason)
     NP.gather.SyncPower(plateData, state.showPower and context.resolvedUnit or nil)
     NP.gather.SyncName(plateData, context.resolvedUnit)
     NP.widgets.SyncList(TARGET_SYNC_WIDGETS, plateData, context, state)
+    -- Called before the headline return below: it is not a pure predicate, and on a
+    -- target transition it clears the GUID and debuffs off a stale duplicate plate.
+    local ownershipValid = NP.identity.ValidatePlateGUIDOwnership(plateData)
     -- Un-targeting mid-cast re-enters headline; drop the bars before the ownership
     -- branch below, which would otherwise leave a pending fade on screen.
     if NP.gather.IsHeadlineActive(plateData) then
         NP.castbar.HidePlateCastVisualsForHeadline(plateData)
         return
     end
-    local ownershipValid = NP.identity.ValidatePlateGUIDOwnership(plateData)
     if not ownershipValid and not NP.castbar.PlateStillCasting(plateData) then
         NP.castbar.HidePlateCastBar(plateData)
     elseif state.showCastbar and NP.castbar.ShouldSkipCastSync(plateData) then

--- a/DragonUI/modules/nameplates/pipeline/gather.lua
+++ b/DragonUI/modules/nameplates/pipeline/gather.lua
@@ -190,6 +190,9 @@ function NP.gather.ApplyVisualState(plateData, snapshot, context, state, reason)
         NP.layout.LayoutCastBarStack(plateData)
     elseif state.showCastbar then
         NP.castbar.SyncCastBar(plateData)
+    elseif NP.gather.IsHeadlineActive(plateData) then
+        -- Name only; a plain hide would leave the native bar and pending fades up.
+        NP.castbar.HidePlateCastVisualsForHeadline(plateData)
     else
         NP.castbar.HidePlateCastBar(plateData)
     end
@@ -1034,7 +1037,7 @@ end
 function NP.gather.RefreshPlateCastbar(plateData, reason)
     -- Headline mode hides the castbar regardless of the cast event path.
     if NP.gather.IsHeadlineActive(plateData) then
-        NP.castbar.HidePlateCastBar(plateData)
+        NP.castbar.HidePlateCastVisualsForHeadline(plateData)
         return
     end
     local ownershipValid = NP.identity.ValidatePlateGUIDOwnership(plateData)
@@ -1069,6 +1072,12 @@ function NP.gather.RefreshPlateTargetState(plateData, reason)
     NP.gather.SyncPower(plateData, state.showPower and context.resolvedUnit or nil)
     NP.gather.SyncName(plateData, context.resolvedUnit)
     NP.widgets.SyncList(TARGET_SYNC_WIDGETS, plateData, context, state)
+    -- Un-targeting mid-cast re-enters headline; drop the bars before the ownership
+    -- branch below, which would otherwise leave a pending fade on screen.
+    if NP.gather.IsHeadlineActive(plateData) then
+        NP.castbar.HidePlateCastVisualsForHeadline(plateData)
+        return
+    end
     local ownershipValid = NP.identity.ValidatePlateGUIDOwnership(plateData)
     if not ownershipValid and not NP.castbar.PlateStillCasting(plateData) then
         NP.castbar.HidePlateCastBar(plateData)


### PR DESCRIPTION
## Problem

In headline (name-only) mode, friendly nameplates should show just the name — no health bar, no power bar, no cast bar. Cast bars still appeared, in two ways:

- the **native Blizzard** plate cast bar became visible, and
- **DragonUI's own** cast bar appeared — most often after clicking a plate to target it, and typically lingering right as the spell ended.

Non-headline mode was unaffected.

## Before / After

| Before | After |
| --- | --- |
| <img width="1309" height="763" alt="WoWScrnShot_081926_101647" src="https://github.com/user-attachments/assets/db1d470d-128d-4e3f-993b-d845c6037193" /> | <img width="1337" height="752" alt="WoWScrnShot_081926_103423" src="https://github.com/user-attachments/assets/77022e3a-1331-42f1-ab8c-cd5f3f364419" /> |

## Root cause

Every headline branch called `HidePlateCastBar(plateData)` *without* `force`, and none of them touched the native bar. Four leaks followed:

1. **The native bar was never suppressed on the headline path.** `HideNativeCastVisual` was only reachable from the *sync* paths, while `SyncShowVKeyCastbarCVar` forces `showVKeyCastbar = 1` — so the client genuinely draws a cast bar that nothing hid.
2. **The non-forced hide refuses to hide.** It deliberately early-returns during a pending success fade and while a timed cast is still running, and it can *re-show* the interrupted hold visual. Un-targeting a plate mid-cast (headline returns via `headlineExcludeTarget`) left the bar up for the rest of the cast plus its ~1.3 s fade.
3. **`StartMonitorCast` had no headline check at all** — the CLEU off-target monitor called `bar:Show()` unconditionally.
4. **The party/raid gate was too narrow and start-only.** `PartyRaidCastTracker:StartCast` gated on `IsFriendlyNameOnlyActive`, which misses friendly-NPC headline, and only at cast start — nothing hid `minaPartyCast` when a plate entered headline mid-cast.

## Changes

- New `NP.castbar.HidePlateCastVisualsForHeadline()`: reuses the existing `ResetPlateCastBar` hard reset (drops both addon bars past their pending fades), hides the plate sparks, clears the monitor backup so `SyncCastBar` cannot resurrect the bar, deregisters the cast tick, then hides the native visual. It calls `HideNativeCastVisual` rather than `SuppressNativeCastVisual`, whose one-shot `_nativeCastSuppressed` flag would no-op from the second cast onward.
- All three headline branches in `gather.lua` route through it. In `RefreshPlateTargetState` the check is hoisted above the ownership branch, which would otherwise leave a pending fade on screen.
- Headline gates added to `ShowInterruptedState` (one guard covering all four interrupt callers), `StartMonitorCast`, `SyncCastBar`, and the native `OnNativeCastShown` hook — the last one kills the Blizzard bar at the moment the client shows it.
- `PartyRaidCastTracker:StartCast` now gates on `IsHeadlineActive`, so friendly NPCs are covered as well as party/raid players.

Deliberately unchanged: with `showCastBar = false` and headline **off**, the old path still runs — that config restores the CVar, so the native bar may legitimately be wanted there. The totem icon-only gate is also untouched.

## Testing

Headline mode on, in a party:

- Party member casts with no target → no bar of any kind on their plate.
- Click the plate mid-cast, then click away mid-cast → the bar disappears immediately; no leftover fill, no white interrupted bar, no fade-out.
- Cast finishes naturally while targeting, un-target at the end → no success flash, no leftover bar.
- Cast interrupted while headline is active → nothing appears.
- Friendly NPC casting in headline → no bar.

Regression checks, all unchanged:

- Headline **off**: party/raid cast bar with spell icon, target cast bar, interrupted and success visuals.
- Hostile plates: off-target CLEU monitor bars, non-interruptible shield, interrupt visuals.
- Toggling `friendlyNameOnly` on/off while a party member is mid-cast leaves no stuck bar in either direction.



